### PR TITLE
ci: 更正CI运行时间cron表达

### DIFF
--- a/.github/workflows/update-flake.yaml
+++ b/.github/workflows/update-flake.yaml
@@ -8,10 +8,7 @@ on:
     paths:
       - ".github/workflows/update-flake.yaml"
   schedule:
-    # rebuild everyday at 2:51
-    # TIP: Choose a random time here so not all repositories are build at once:
-    # https://www.random.org/clock-times/?num=1&earliest=01%3A00&latest=08%3A00&interval=5&format=html&rnd=new
-    - cron:  '31 2 * * 5'
+    - cron: '31 2 * * 5'
 
 permissions:
   contents: write


### PR DESCRIPTION
按照11行注释说明，此ci应该在每天的2:51运行，而原cron表达式为每周五的2:31运行。